### PR TITLE
1.18

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,6 +29,6 @@
   "depends": {
     "fabricloader": ">=0.11.3",
     "minecraft": "1.18.x",
-    "java": ">=17"
+    "java": ">=16"
   }
 }

--- a/src/main/resources/modid.mixins.json
+++ b/src/main/resources/modid.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "nl.andrewlalis.speed_carts.mixin",
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_16",
   "mixins": [
     "AbstractMinecartMixin"
   ],


### PR DESCRIPTION
Allow compatibilityLevel to be set to Java 16 for the Fabric API. Built and tested.