### PR TITLE
Update to 1.19.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,14 +3,14 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/versions.html
-	minecraft_version=1.19
-	yarn_mappings=1.19+build.1
-	loader_version=0.14.7
+	minecraft_version=1.19.3
+	yarn_mappings=1.19.3+build.5
+	loader_version=0.14.14
 
 # Mod Properties
-	mod_version = 1.4.0
+	mod_version = 1.4.1
 	maven_group = nl.andrewlalis
 	archives_base_name = speed-carts
 
 # Dependencies
-	fabric_version=0.55.3+1.19
+	fabric_version=0.73.2+1.19.3

--- a/src/main/java/nl/andrewlalis/speed_carts/mixin/AbstractMinecartMixin.java
+++ b/src/main/java/nl/andrewlalis/speed_carts/mixin/AbstractMinecartMixin.java
@@ -154,7 +154,7 @@ public abstract class AbstractMinecartMixin extends Entity {
 				if (this.hasPlayerRider()) {
 					PlayerEntity player = (PlayerEntity) this.getFirstPassenger();
 					if (player != null) {
-						player.playSound(SoundEvents.BLOCK_NOTE_BLOCK_BELL, SoundCategory.PLAYERS, 1.0f, 1.0f);
+						player.playSound(SoundEvents.BLOCK_REDSTONE_TORCH_BURNOUT, SoundCategory.PLAYERS, 1.0f, 1.0f);
 					}
 				}
 				return true;


### PR DESCRIPTION
an error could occur when the server tried to play a sound at the player due to noteblocks being rewritten in one of the 1.20 snapshots and carried over to 1.19.3. Everything else works fine; `gradle.properties` updated to reflect the update, and changed the bugged sound to the redstone torch burnout sound temporarily until another way to use the noteblock sound is used.